### PR TITLE
Retry different camera index on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,11 @@ To download the unique calibration file for your camera:
 
 Replace the serial number in the URL with the one on your camera.
 
-To figure out the camera index for your calicam, unplug it if you have it plugged in and run:
-> ls /dev
+Add your user to video group if you want to find the camera index automatically.
+> sudo usermod -a -G video $USER
 
-If you have any other cameras connected to your computer like a webcam they will show up as video sources, take note of them. Then connect the calicam and run the command again. You should see 2 more video sources pop up. The first of those is your calicam and you should use that index.
+The node will try finding the correct index of your calicam. If it fails you will have to [manually specify](#7-Manually-find-camera-index) it in the params file.
 
-![find_camera_index.png](./photos/find_camera_index.png)
 
 Run with launch:
 > ros2 launch calicam_ros calicam
@@ -90,6 +89,15 @@ If using a mono camera only the left camera will be published but both topics wi
 The suffix for each frame is the node name. In this example it is the default node name *calicam*. As an example if the node name is changed to calicam_1 then the three frames would be named as follows: calicam_1, calicam_1_left, calicam_1_right
 
 The calicam frame is in the ros coordinate system (x-forwards, y-left, z-up). It's position is the same as the calicam_left frame. The left and right camera frames are in the camera coordinate frame (z-forwards, x-right, y-down). The calicam frame rotates these frames to the ros coordinate system. If you are using a mono camera then the right frame won't exist.
+
+## 7. Manually find camera index
+
+To figure out the camera index for your calicam, unplug it if you have it plugged in and run:
+> ls /dev
+
+If you have any other cameras connected to your computer like a webcam they will show up as video sources, take note of them. Then connect the calicam and run the command again. You should see 2 more video sources pop up. The first of those is your calicam and you should use that index.
+
+![find_camera_index.png](./photos/find_camera_index.png)
 
 ## TO DO
 

--- a/include/calicam_ros/calicam.hpp
+++ b/include/calicam_ros/calicam.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <iostream>
 
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_ros/static_transform_broadcaster.h>
@@ -11,6 +12,10 @@
 #include <opencv2/opencv.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/videoio.hpp>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <linux/videodev2.h>
 
 #include "calibration.hpp"
 #include "stereo_rectifier.hpp"

--- a/params/calicam.yaml
+++ b/params/calicam.yaml
@@ -3,6 +3,6 @@ calicam:
     calibration_file: ""
     fov: 100.0
     fps: 30.0
-    camera_index: 0
+    camera_index: -1
     undistort_rectify: true
     monochrome: false

--- a/src/calicam.cpp
+++ b/src/calicam.cpp
@@ -169,7 +169,8 @@ void CaliCam::updateHandler()
 {
     if(!vCapture.isOpened())
     {
-        RCLCPP_ERROR(get_logger(), "CAN'T CONNECTO TO CAMERA %i", cameraIndex);
+        RCLCPP_ERROR(get_logger(), "CAN'T CONNECT TO CAMERA %i, trying %i", cameraIndex, cameraIndex + 1);
+        cameraIndex = (cameraIndex + 1) % 16;
         resetCamera();
         return;
     }

--- a/src/calicam.cpp
+++ b/src/calicam.cpp
@@ -168,7 +168,8 @@ void CaliCam::updateHandler()
 {
     if(!vCapture.isOpened())
     {
-        RCLCPP_INFO(get_logger(), "Can't connect to camera %i, trying to find Calicam ", cameraIndex);
+        RCLCPP_WARN_THROTTLE(get_logger(), *this->get_clock(), 2000,
+        					 "Can't connect to camera %i, trying to find Calicam ", cameraIndex);
 
         int maxCameras = 64; // Set the maximum number of cameras to search
         for(int i = 0; i < maxCameras; ++i)
@@ -195,8 +196,9 @@ void CaliCam::updateHandler()
         }
 
         // If no calicam is found, log an error or handle accordingly
-        RCLCPP_FATAL(get_logger(), "Calicam not found among available cameras");
-        exit(-1);
+    	RCLCPP_WARN_THROTTLE(get_logger(), *this->get_clock(), 2000,
+                         	 "Calicam not found among available cameras. Retrying...");
+   	 	return;
     }
 
 


### PR DESCRIPTION
When using the package with multiple other cameras, you would need to set the camera index every time since it depends on the plug order, this way it will try to find the right index on failure.